### PR TITLE
feat(serde): add optional serde derive for enums and Sample

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,13 @@ description = "Realtime procedurally generated sound effects"
 keywords = ["sfx", "audio", "gamedev", "sound", "procedural"]
 categories = ["game-development", "multimedia", "multimedia::audio", "simulation"]
 
+[features]
+default = []
+serde = ["dep:serde"]
+
 [dependencies]
 randomize = "3.0.1"
+serde = { version = "1.0.193", features = ["derive"], optional = true }
 
 [dev-dependencies]
 cpal = "0.15.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ use envelope::{Envelope, State};
 use oscillator::Oscillator;
 pub use oscillator::{DutyCycle, OscillatorType};
 use std::{cell::RefCell, collections::HashMap};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Audio sample that procedurally generates it's sound.
 ///
@@ -65,6 +67,7 @@ use std::{cell::RefCell, collections::HashMap};
 /// ```
 ///
 /// [`Generator`]: struct.Generator.html
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone)]
 pub struct Sample {
     volume: Option<f32>,

--- a/src/oscillator.rs
+++ b/src/oscillator.rs
@@ -1,9 +1,12 @@
 use randomize::{formulas, PCG32};
 use std::{cell::RefCell, f32::consts::PI};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 const PI2: f32 = PI * 2.0;
 
 /// Possible values for the duty cycle of the square wave.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum DutyCycle {
     /// A duty cycle of 12.5%.
@@ -36,6 +39,7 @@ impl Default for DutyCycle {
 }
 
 /// Wave form generation type.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum OscillatorType {
     /// A continuus tone.


### PR DESCRIPTION
**What:**
Make structs and enums serializable

**Why:**
This would have been useful for something I'm working on, currently I'm converting to and from strings

**How:**
Add optional dependency `serde`, disabled by default
Add feature to enable `serde`
Add derive serde for `Sample`, `OscillatorType` and `DutyCycle` 

**Risks:**
There should be none as the feature is optional and off by default it won't effect any existing lib or app using this 
